### PR TITLE
Change methods for computing IVD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoLayerDirectNumericalShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.4.3"
+version = "0.4.5"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/kernelfunctions.jl
+++ b/src/kernelfunctions.jl
@@ -37,6 +37,17 @@ wᶜᶜᶜ(w, grid) = KernelFunctionOperation{Center, Center, Center}(ℑzᵃᵃ
 ∂b∂z(model) = ∂b∂z(model.buoyancy, model.grid, model.tracers)
 ∂b∂z(b, grid, tracers) = KernelFunctionOperation{Center, Center, Face}(∂z_b, grid, b, tracers)
 
+@inline vertical_buoyancy_flux(i, j, k, grid, b::SeawaterBuoyancy, C, w) =
+        -ℑzᵃᵃᶜ(i, j, k, w) * buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C)
+@inline function vertical_buoyancy_flux(model)
+
+    grid = model.grid
+    b = model.buoyancy.model
+    C = model.tracers
+    w = model.velocities.w
+
+    return KernelFunctionOperation{Center, Center, Center}(vertical_buoyancy_flux, grid, b, C, w)
+end
 @inline function Kᵥ(i, j, k, grid, b::SeawaterBuoyancy, C, w)
 
     if ∂z_b(i, j, k, grid, b, C) != 0


### PR DESCRIPTION
Save horizontally integrated vertical buoyancy flux and vertical buoyancy gradient and compute the inferred vertical diffusivity in post processing.

Closes #138 