### PR TITLE
Rename `DNS` - > `DNSModel`, `TLDNS_simulation_setup` + update README.md + change default behaviour of `overwrite_existing`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoLayerDirectNumericalShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.4.5"
+version = "0.5.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/jbisits/TwoLayerDirectNumericalShenanigans.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jbisits/TwoLayerDirectNumericalShenanigans.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-A Julia package (unregistered) to explore the cabbeling instability using Direct Numerical Simulation experiments built with [Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl).
+A Julia package (unregistered) to explore two layer systems using Direct Numerical Simulation experiments built with [Oceananigans.jl](https://github.com/CliMA/Oceananigans.jl).
 
 To add the package (assuming julia is already installed):
 

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -6,8 +6,8 @@ diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 100)
 
 ## Setup the model
-model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-            reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+                 reference_density = REFERENCE_DENSITY)
 
 ## set initial conditions
 T₀ᵘ = -1.5
@@ -15,23 +15,23 @@ S₀ᵘ = (stable = 34.551, cabbeling = 34.58, unstable = 34.59)
 cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ.cabbeling, T₀ᵘ)
 initial_conditions = TwoLayerInitialConditions(cabbeling)
 transition_depth = find_depth(model, INTERFACE_LOCATION)
-profile_function = StepChange(transition_depth)#HyperbolicTangent(INTERFACE_LOCATION, 1.0)
+profile_function = StepChange(transition_depth)
 tracer_perturbation_depth = find_depth(model, INTERFACE_LOCATION / 2)
 tracer_perturbation = SalinityGaussianProfile(tracer_perturbation_depth, 0.0, 1.5)
 noise_depth = find_depth(model, INTERFACE_LOCATION)
 initial_noise = SalinityNoise(noise_depth, 1e-2)
 
-dns = TwoLayerDNS(model, profile_function, initial_conditions; initial_noise)
+tldns = TwoLayerDNS(model, profile_function, initial_conditions; initial_noise)
 
-set_two_layer_initial_conditions!(dns)
+set_two_layer_initial_conditions!(tldns)
 
 ## build the simulation
 Δt = 1e-4
 stop_time = 60
 save_schedule = 0.5 # seconds
 output_path = joinpath(@__DIR__, "outputs/")
-simulation = DNS_simulation_setup(dns, Δt, stop_time, save_schedule,
-                                  overwrite_existing = true; output_path)
+simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule,
+                                    overwrite_existing = true; output_path)
 
 ## Run the simulation
 run!(simulation)

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -29,9 +29,8 @@ set_two_layer_initial_conditions!(tldns)
 Δt = 1e-4
 stop_time = 60
 save_schedule = 0.5 # seconds
-output_path = joinpath(@__DIR__, "outputs/")
-simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule,
-                                    overwrite_existing = true; output_path)
+output_path = joinpath(@__DIR__, "outputs")
+simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; output_path)
 
 ## Run the simulation
 run!(simulation)

--- a/src/TwoLayerDirectNumericalShenanigans.jl
+++ b/src/TwoLayerDirectNumericalShenanigans.jl
@@ -28,7 +28,7 @@ abstract type AbstractProfileFunction end
 "Abstract supertype for dns initial conditions."
 abstract type AbstractInitialConditions end
 
-export TwoLayerDNS, DNS, DNS_simulation_setup
+export TwoLayerDNS, DNSModel, TLDNS_simulation_setup
 
 export
     StableUpperLayerInitialConditions,

--- a/src/twolayerdns.jl
+++ b/src/twolayerdns.jl
@@ -187,7 +187,7 @@ function TLDNS_simulation_setup(tldns::TwoLayerDNS, Δt::Number,
 
     # Custom saved output
     # Potential density
-    σ = seawater_density(model, geopotential_height = 0)
+    σ = seawater_density(model, geopotential_height = density_reference_gp_height)
 
     # Inferred vertical temperature diffusivity
     # T_mean = Average(T)

--- a/src/twolayerdns.jl
+++ b/src/twolayerdns.jl
@@ -128,10 +128,10 @@ function grid_stretching(Lz::Number, Nz::Number, refinement::Number, stretching:
 
 end
 """
-    function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number, stop_time::Number,
+    function TLDNS_simulation_setup(tldns::TwoLayerDNS, Δt::Number, stop_time::Number,
                                     save_schedule::Number;  cfl = 0.75, diffusive_cfl = 0.75,
                                     max_change = 1.2, max_Δt = 1e-1)
-Setup a `Simulation` of `dns` from `initial_conditions` that are of type `TwoLayerInitialConditions`.
+Setup a `Simulation` of `tldns` from `initial_conditions` that are of type `TwoLayerInitialConditions`.
 Important non-dimensional numbers that are part of this experiment are computed and saved
 to the simulation output file.
 
@@ -144,7 +144,7 @@ the course of a simulation;
 - `savefile` name of the file to save the data to,
 - `save_schedule` number (representing time in seconds) at which to save model output, e.g.,
 `save_schedule = 1` saves output every second;
-- `output_writer` a `Symbol` (either `:netcdf` or `:jld2`) choosing whether to save data in
+- `save_file` a `Symbol` (either `:netcdf` or `:jld2`) choosing whether to save data in
 `NetCDF` format (`.nc`) ot `JLD2` format ('.jld2).
 
 ## Keyword arguments:
@@ -159,12 +159,12 @@ there is no `Checkpointer`.
 - `max_Δt` the maximum timestep;
 - `density_reference_gp_height` for the seawater density calculation;
 - `save_velocities` defaults to `false`, if `true` model velocities will be saved to output;
-- `overwrite_existing` whether the output overwrites a file of the same name, default is
-`false`.
+- `overwrite_saved_output` whether the output overwrites a file of the same name, default is
+`true`.
 """
-function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
-                                stop_time::Number, save_schedule::Number,
-                                output_writer::Symbol=:netcdf;
+function TLDNS_simulation_setup(tldns::TwoLayerDNS, Δt::Number,
+                                stop_time::Number, save_schedule::Number;
+                                save_file = :netcdf,
                                 output_path = SIMULATION_PATH,
                                 checkpointer_time_interval = nothing,
                                 cfl = 0.75,
@@ -172,10 +172,10 @@ function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
                                 max_change = 1.2,
                                 max_Δt = 1e-1,
                                 density_reference_gp_height = 0,
-                                overwrite_existing = false,
+                                overwrite_saved_output = nothing,
                                 save_velocities = false)
 
-    model = dns.model
+    model = tldns.model
     simulation = Simulation(model; Δt, stop_time)
 
     # time step adjustments
@@ -204,9 +204,6 @@ function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
     # Minimum in space Kolmogorov length scale
     η_space(model) = (model.closure.ν^3 / maximum(ϵ))^(1/4)
 
-    # Volume integrated TKE dissipation
-    ∫ϵ = Integral(ϵ)
-
     # Dimensions and attributes for custom saved output
     dims = Dict("η_space" => ())
     oa = Dict(
@@ -227,11 +224,10 @@ function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
         merge!(outputs, velocities)
     end
 
-    filename = form_filename(dns, stop_time, output_writer, output_path)
-    simulation.output_writers[:outputs] = output_writer == :netcdf ?
-                                            NetCDFOutputWriter(model, outputs;
-                                                            filename,
-                                                            overwrite_existing,
+    filename = form_filename(tldns, stop_time, save_file, output_path)
+    simulation.output_writers[:outputs] = save_file == :netcdf ?
+                                            NetCDFOutputWriter(model, outputs; filename,
+                                                            overwrite_existing = overwrite_saved_output,
                                                             schedule = TimeInterval(save_schedule),
                                                             dimensions = dims,
                                                             output_attributes = oa
@@ -239,10 +235,10 @@ function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
                                             JLD2OutputWriter(model, outputs;
                                                             filename,
                                                             schedule = TimeInterval(save_schedule),
-                                                            overwrite_existing)
+                                                            overwrite_existing = overwrite_saved_output)
 
-    non_dimensional_numbers!(simulation, dns)
-    predicted_maximum_density!(simulation, dns)
+    non_dimensional_numbers!(simulation, tldns)
+    predicted_maximum_density!(simulation, tldns)
 
     # progress reporting
     simulation.callbacks[:progress] = Callback(simulation_progress, IterationInterval(100))
@@ -253,26 +249,26 @@ function TLDNS_simulation_setup(dns::TwoLayerDNS, Δt::Number,
 
 end
 """
-    function form_filename(dns::TwoLayerDNS, stop_time::Number, output_writer::Symbol, output_path::AbstractString)
+    function form_filename(tldns::TwoLayerDNS, stop_time::Number, save_file, output_path)
 Create a filename for saved output based on the `profile_function`,`initial_conditions`,
 `tracer_perturbation` and length of the simulation.
 """
-function form_filename(dns::TwoLayerDNS, stop_time::Number, output_writer::Symbol, output_path::AbstractString)
+function form_filename(tldns::TwoLayerDNS, stop_time::Number, save_file, output_path)
 
-    pf_string = lowercase(string(typeof(dns.profile_function))[1:findfirst('{', string(typeof(dns.profile_function))) - 1])
-    ic_type = typeof(dns.initial_conditions)
+    pf_string = lowercase(string(typeof(tldns.profile_function))[1:findfirst('{', string(typeof(tldns.profile_function))) - 1])
+    ic_type = typeof(tldns.initial_conditions)
     ic_string = ic_type <: StableTwoLayerInitialConditions ? "stable" :
                             ic_type <: CabbelingTwoLayerInitialConditions ?
                                 "cabbeling" : ic_type <: UnstableTwoLayerInitialConditions ?
                                               "unstable" : ic_type <: IsohalineTwoLayerInitialConditions ?
                                                             "isohaline" : "isothermal"
 
-    tp_string = lowercase(string(typeof(dns.tracer_perturbation)))
+    tp_string = lowercase(string(typeof(tldns.tracer_perturbation)))
     tp_find = isnothing(findfirst('{', tp_string)) ? length(tp_string) :
                                                      findfirst('{', tp_string) - 1
     stop_time_min = stop_time / 60 ≥ 1 ? string(round(Int, stop_time / 60)) :
                                          string(round(stop_time / 60; digits = 2))
-    filetype = output_writer == :netcdf ? ".nc" : ".jld2"
+    filetype = save_file == :netcdf ? ".nc" : ".jld2"
     savefile = ic_string *"_"* pf_string *"_"* tp_string[1:tp_find] *"_"* stop_time_min * "min" * filetype
 
     # make a simulation directory if one is not present
@@ -285,11 +281,11 @@ function form_filename(dns::TwoLayerDNS, stop_time::Number, output_writer::Symbo
 
 end
 """
-    function checkpointer_setup!(simulation, model, checkpointer_time_interval)
+    function checkpointer_setup!(simulation, model, output_path, checkpointer_time_interval)
 Setup a `Checkpointer` at `checkpointer_time_interval` for a `simulation`
 """
-function checkpointer_setup!(simulation::Simulation, model::Oceananigans.AbstractModel,
-                             output_path::AbstractString, checkpointer_time_interval::Number)
+function checkpointer_setup!(simulation, model, output_path,
+                             checkpointer_time_interval::Number)
 
     dir = output_path == SIMULATION_PATH ? CHECKPOINT_PATH :
                                            joinpath(output_path, "model_checkpoints/")

--- a/test/initialconditions_test.jl
+++ b/test/initialconditions_test.jl
@@ -1,8 +1,8 @@
 # Need to write these to check things are set at the right level in the right field
 diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 500)
-model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-            reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+                reference_density = REFERENCE_DENSITY)
 
 ## set initial conditions, currently there are four options available in this submodule
 initial_conditions = StableTwoLayerInitialConditions(0, 0, 0, 0, 0, 0)

--- a/test/kernelfunction_test.jl
+++ b/test/kernelfunction_test.jl
@@ -7,8 +7,8 @@ using GibbsSeaWater
 diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 100)
 
-model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-            reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+                reference_density = REFERENCE_DENSITY)
 
 z = znodes(model.grid, Center())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,7 @@ include("initialconditions_test.jl")
 
     for tb ∈ tracer_profile_perturbations
 
-        model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                     reference_density = REFERENCE_DENSITY)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, tracer_perturbation = tb)
         set_two_layer_initial_conditions!(dns)
@@ -80,7 +80,7 @@ end
 
     for tb ∈ tracer_blob_perturbations
 
-        model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                     reference_density = REFERENCE_DENSITY)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, tracer_perturbation = tb)
         set_two_layer_initial_conditions!(dns)
@@ -94,7 +94,7 @@ end
 
     for tn ∈ tracer_noise_perturbations
 
-        model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                     reference_density = REFERENCE_DENSITY)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, initial_noise = tn)
         set_two_layer_initial_conditions!(dns)
@@ -104,7 +104,7 @@ end
     end
     for tnv ∈ tracer_noise_perturbations_vec
 
-        model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                     reference_density = REFERENCE_DENSITY)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, initial_noise = tnv)
         set_two_layer_initial_conditions!(dns)
@@ -117,7 +117,7 @@ end
 
 @testset "Step change" begin
 
-    model = DNS(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                 reference_density = REFERENCE_DENSITY)
     profile_function = StepChange(z[depth_idx])
     initial_conditions = TwoLayerInitialConditions(34.551, -1.5, 34.7, 0.5)


### PR DESCRIPTION
Closes #139 (for now..)
Closes #152 
Closes #156 

## Breaking changes

- `DNS` renamed to `DNSModel`
- `DNS_simulation_setup` renamed to `TLDNS_simulation_setup`
