### PR TITLE
Break saving output up into multiple functions and files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoLayerDirectNumericalShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -30,7 +30,8 @@ set_two_layer_initial_conditions!(tldns)
 stop_time = 60
 save_schedule = 0.5 # seconds
 output_path = joinpath(@__DIR__, "outputs/")
-simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; output_path)
+checkpointer_time_interval = 30
+simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; output_path, checkpointer_time_interval)
 
 ## Run the simulation
 run!(simulation)

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -31,7 +31,8 @@ stop_time = 60
 save_schedule = 0.5 # seconds
 output_path = joinpath(@__DIR__, "outputs/")
 checkpointer_time_interval = 30
-simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; output_path, checkpointer_time_interval)
+simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule;
+                                    output_path, checkpointer_time_interval)
 
 ## Run the simulation
 run!(simulation)

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -29,7 +29,7 @@ set_two_layer_initial_conditions!(tldns)
 Δt = 1e-4
 stop_time = 60
 save_schedule = 0.5 # seconds
-output_path = joinpath(@__DIR__, "outputs")
+output_path = joinpath(@__DIR__, "outputs/")
 simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; output_path)
 
 ## Run the simulation

--- a/src/output_utils.jl
+++ b/src/output_utils.jl
@@ -316,14 +316,16 @@ function non_dimensional_numbers!(simulation::Simulation, dns::TwoLayerDNS)
     if simulation.output_writers[:tracers] isa NetCDFOutputWriter
 
         for key ∈ simulation.output_writers.keys
-            NCDataset(simulation.output_writers[key].filepath, "a") do ds
-                ds.attrib["EOS"] = summary(model.buoyancy.model.equation_of_state.seawater_polynomial)
-                ds.attrib["Reference density"] = "$(model.buoyancy.model.equation_of_state.reference_density)kgm⁻³"
-                ds.attrib["ν"]  = "$(model.closure.ν) m²s⁻¹"
-                ds.attrib["κₛ"] = "$(model.closure.κ.S) m²s⁻¹"
-                ds.attrib["κₜ"] = "$(model.closure.κ.T) m²s⁻¹"
-                for key ∈ keys(nd_nums)
-                    ds.attrib[key] = nd_nums[key]
+            if key != :checkpointer
+                NCDataset(simulation.output_writers[key].filepath, "a") do ds
+                    ds.attrib["EOS"] = summary(model.buoyancy.model.equation_of_state.seawater_polynomial)
+                    ds.attrib["Reference density"] = "$(model.buoyancy.model.equation_of_state.reference_density)kgm⁻³"
+                    ds.attrib["ν"]  = "$(model.closure.ν) m²s⁻¹"
+                    ds.attrib["κₛ"] = "$(model.closure.κ.S) m²s⁻¹"
+                    ds.attrib["κₜ"] = "$(model.closure.κ.T) m²s⁻¹"
+                    for key ∈ keys(nd_nums)
+                        ds.attrib[key] = nd_nums[key]
+                    end
                 end
             end
         end

--- a/src/twolayerdns.jl
+++ b/src/twolayerdns.jl
@@ -326,7 +326,7 @@ function save_computed_output!(simulation, model, save_schedule, save_file, file
                                                 schedule = TimeInterval(save_schedule),
                                                 output_attributes = oa
                                                 ) :
-                                JLD2OutputWriter(model, outputs;
+                                JLD2OutputWriter(model, computed_outputs;
                                                 filename = filename*"_computed_output",
                                                 schedule = TimeInterval(save_schedule),
                                                 overwrite_existing = overwrite_saved_output)

--- a/src/twolayerdns.jl
+++ b/src/twolayerdns.jl
@@ -226,7 +226,7 @@ function output_directory(tldns::TwoLayerDNS, stop_time::Number, output_path)
                                          string(round(stop_time / 60; digits = 2))
     expt_dir = ic_string *"_"* pf_string *"_"* tp_string[1:tp_find] *"_"* stop_time_min * "min"
 
-    output_dir = joinpath(output_path, expt_dir)
+    output_dir = mkpath(joinpath(output_path, expt_dir))
     # make a simulation directory if one is not present
     if !isdir(output_dir)
         mkdir(output_dir)

--- a/test/output_test.jl
+++ b/test/output_test.jl
@@ -1,0 +1,30 @@
+function run_sim(save_file)
+
+    diffusivities = (ν = 0, κ = (S = 0, T = 0))
+    resolution = (Nx = 10, Ny = 10, Nz = 100)
+
+    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
+                    reference_density = REFERENCE_DENSITY)
+
+    T₀ᵘ = -1.5
+    S₀ᵘ = 34.58
+    cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ, T₀ᵘ)
+    initial_conditions = TwoLayerInitialConditions(cabbeling)
+    transition_depth = find_depth(model, INTERFACE_LOCATION)
+    td_idx = findfirst(znodes(model.grid, Center()) .== transition_depth)
+    profile_function = StepChange(transition_depth)
+    tldns = TwoLayerDNS(model, profile_function, initial_conditions)
+
+    set_two_layer_initial_conditions!(tldns)
+
+    ## build the simulation
+    Δt = 1
+    stop_time = 10
+    save_schedule = 5 # seconds
+    output_path = joinpath(@__DIR__, "outputs/")
+    simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; save_file, output_path)
+
+    run!(simulation)
+
+    return simulation, td_idx, tldns
+end

--- a/test/output_test.jl
+++ b/test/output_test.jl
@@ -22,7 +22,8 @@ function run_sim(save_file)
     stop_time = 10
     save_schedule = 5 # seconds
     output_path = joinpath(@__DIR__, "outputs/")
-    simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule; save_file, output_path)
+    simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule,
+                                        TLDNS.save_computed_output!; save_file, output_path)
 
     run!(simulation)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using TwoLayerDirectNumericalShenanigans, Test
 using TwoLayerDirectNumericalShenanigans: perturb_tracer
 using SeawaterPolynomials
+using NCDatasets, JLD2
 import SeawaterPolynomials.ρ
 using GibbsSeaWater: gsw_p_from_z
 using CUDA: has_cuda_gpu
@@ -132,6 +133,50 @@ end
     @test isequal(test_depth, find_depth(model, test_depth))
     test_depth_range = vcat(z[10], z[20])
     @test isequal(z[10:20], find_depth(model, test_depth_range))
+end
+
+include("output_test.jl")
+@testset "Saving output" begin
+
+    @testset "NetCDF" begin
+        simulation, td, tldns = run_sim(:netcdf)
+        NCDataset(simulation.output_writers[:tracers].filepath) do ds
+            S, T = ds[:S], ds[:T]
+            @test all(S[:, :, 1:td, :]     .== tldns.initial_conditions.S₀ˡ)
+            @test all(S[:, :, td+1:end, :] .== tldns.initial_conditions.S₀ᵘ)
+            @test all(T[:, :, 1:td, :]     .== tldns.initial_conditions.T₀ˡ)
+            @test all(T[:, :, td+1:end, :] .== tldns.initial_conditions.T₀ᵘ)
+        end
+        NCDataset(simulation.output_writers[:computed_output].filepath) do ds
+            σ = ds[:σ]
+            @test all(σ[:, :, 1:td, :] .== SeawaterPolynomials.ρ(tldns.initial_conditions.T₀ˡ,
+                                             tldns.initial_conditions.S₀ˡ, 0,
+                                             tldns.model.buoyancy.model.equation_of_state))
+            @test all(σ[:, :, td+1:end, :] .== SeawaterPolynomials.ρ(tldns.initial_conditions.T₀ᵘ,
+                                                 tldns.initial_conditions.S₀ᵘ, 0,
+                                                 tldns.model.buoyancy.model.equation_of_state))
+        end
+    end
+
+    @testset "jld2" begin
+        simulation, td, tldns = run_sim(:jld2)
+        S = FieldTimeSeries(simulation.output_writers[:tracers].filepath, "S")
+        T = FieldTimeSeries(simulation.output_writers[:tracers].filepath, "T")
+        @test all(S.data[:, :, 1:td, :]     .== tldns.initial_conditions.S₀ˡ)
+        @test all(S.data[:, :, td+1:end, :] .== tldns.initial_conditions.S₀ᵘ)
+        @test all(T.data[:, :, 1:td, :]     .== tldns.initial_conditions.T₀ˡ)
+        @test all(T.data[:, :, td+1:end, :] .== tldns.initial_conditions.T₀ᵘ)
+        σ = FieldTimeSeries(simulation.output_writers[:computed_output].filepath, "σ")
+        @test all(σ.data[:, :, 1:td, :] .==
+                SeawaterPolynomials.ρ(tldns.initial_conditions.T₀ˡ,
+                                      tldns.initial_conditions.S₀ˡ, 0,
+                                      tldns.model.buoyancy.model.equation_of_state))
+        @test all(σ.data[:, :, td+1:end, :] .==
+                SeawaterPolynomials.ρ(tldns.initial_conditions.T₀ᵘ,
+                                      tldns.initial_conditions.S₀ᵘ, 0,
+                                      tldns.model.buoyancy.model.equation_of_state))
+    end
+
 end
 
 # include("kernelfunction_test.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using TwoLayerDirectNumericalShenanigans, Test
 using TwoLayerDirectNumericalShenanigans: perturb_tracer
+using Oceananigans.Fields
 using SeawaterPolynomials
 using NCDatasets, JLD2
 import SeawaterPolynomials.ρ


### PR DESCRIPTION
A bug popped up that caused #158. See comments there for more information.

This PR breaks up the saving into multiple files (I wanted to do this anyway #157) and changes `η_space` to `ϵ_maximum` (a `Reduction` using `maximum!`) because as far as I could tell `η_space` was causing the simulation to hang. I am not sure why but likely this solution is an improvement anyway. Functions in `output_utils.jl` have been modified to deal with output being saved across multiple files.

If possible it would be good to make it easy for another user to write their own `save_computed_output!` function which could then be called in `TLDNS_simulation_setup`.

Closes #157 
Closes #158 