### PR TITLE
Add `vertical_tracer_flux` + tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoLayerDirectNumericalShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -31,7 +31,7 @@ stop_time = 60
 save_schedule = 0.5 # seconds
 output_path = joinpath(@__DIR__, "outputs/")
 checkpointer_time_interval = 30
-simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule;
+simulation = TLDNS_simulation_setup(tldns, Δt, stop_time, save_schedule, TLDNS.save_computed_output!;
                                     output_path, checkpointer_time_interval)
 
 ## Run the simulation

--- a/src/kernelfunctions.jl
+++ b/src/kernelfunctions.jl
@@ -1,83 +1,21 @@
-"`(Center, Center, Center)` vertical velocity `Field`"
-wᶜᶜᶜ(model) = wᶜᶜᶜ(model.velocities.w, model.grid)
-wᶜᶜᶜ(w, grid) = KernelFunctionOperation{Center, Center, Center}(ℑzᵃᵃᶜ, grid, w)
-"`(Center, Center, Face)` vertical buoyancy gradient `Field`"
-∂b∂z(model) = ∂b∂z(model.buoyancy, model.grid, model.tracers)
-∂b∂z(b, grid, tracers) = KernelFunctionOperation{Center, Center, Face}(∂z_b, grid, b, tracers)
-
-@inline vertical_buoyancy_flux(i, j, k, grid, b::SeawaterBuoyancy, C, w) =
-        -ℑzᵃᵃᶜ(i, j, k, w) * buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C)
-@inline function vertical_buoyancy_flux(model)
+@inline tracer_perturbationᶜᶜᶜ(i, j, k, grid, tracer, tracer_mean) =
+    tracer[i, j, k] - tracer_mean[i, j, k]
+# Only needed for testing
+@inline function tracer_perturbation(model, tracer)
 
     grid = model.grid
-    b = model.buoyancy.model
-    C = model.tracers
-    w = model.velocities.w
+    tracer_mean = Field(Average(tracer))
 
-    return KernelFunctionOperation{Center, Center, Center}(vertical_buoyancy_flux, grid, b, C, w)
-end
-@inline function Kᵥ(i, j, k, grid, b::SeawaterBuoyancy, C, w)
-
-    if ∂z_b(i, j, k, grid, b, C) != 0
-        (-ℑzᵃᵃᶜ(i, j, k, w) * buoyancy_perturbationᶜᶜᶜ(i, j, k, grid, b, C)) / ∂z_b(i, j, k, grid, b, C)
-    else
-        0
-    end
-
-end
-function InferredVerticalDiffusivity(model)
-
-    grid = model.grid
-    b = model.buoyancy.model
-    C = model.tracers
-    w = model.velocities.w
-
-    return KernelFunctionOperation{Center, Center, Center}(Kᵥ, grid, b, C, w)
+    return KernelFunctionOperation{Center, Center, Center}(tracer_perturbationᶜᶜᶜ, grid, tracer, tracer_mean)
 end
 
-@inline tracer_perturbationᶜᶜᶜ(i, j, k, grid, tracer, tracer_mean) = tracer[i, j, k] - tracer_mean
-@inline vertical_tracer_flux(i, j, k, grid, tracer, tracer_mean, w) =
+@inline vtf(i, j, k, grid, tracer, tracer_mean, w) =
         -ℑzᵃᵃᶜ(i, j, k, w) * tracer_perturbationᶜᶜᶜ(i, j, k, grid, tracer, tracer_mean)
 @inline function vertical_tracer_flux(model, tracer)
 
     grid = model.grid
-    tracer_mean = Average(tracer)
+    tracer_mean = Field(Average(tracer))
     w = model.velocities.w
 
-    return KernelFunctionOperation{Center, Center, Center}(vertical_tracer_flux, grid, tracer, tracer_mean, w)
+    return KernelFunctionOperation{Center, Center, Center}(vtf, grid, tracer, tracer_mean, w)
 end
-
-## This has been implemented (by me) in Oceananigans.jl as of v0.89.3. Once I know
-# everything is working I will remove this in favour of Oceananigans.jl version.
-
-# "Extend `ρ′` to compute at user defined reference geopotential height"
-# SeawaterPolynomials.ρ(i, j, k, grid, eos, θ, sᴬ) = ρ(θ_and_sᴬ(i, j, k, θ, sᴬ)..., Zᶜᶜᶜ(i, j, k, grid),eos)
-# SeawaterPolynomials.ρ(i, j, k, grid, eos, θ, sᴬ, Zᵣ) = ρ(θ_and_sᴬ(i, j, k, θ, sᴬ)..., Zᵣ, eos)
-# """
-#     function densityᶜᶜᶜ(i, j, k, grid, b::SeawaterBuoyancy, C)
-# Compute the density of seawater at grid point `(i, j, k)` using `SeawaterBuoyancy`.
-# """
-# @inline function densityᶜᶜᶜ(i, j, k, grid, b::SeawaterBuoyancy, C)
-#     T, S = get_temperature_and_salinity(b, C)
-#     return ρ(i, j, k, grid, b.equation_of_state, T, S)
-# end
-# density(model) = density(model.buoyancy, model.grid, model.tracers)
-# density(b, grid, tracers) =
-#     KernelFunctionOperation{Center, Center, Center}(densityᶜᶜᶜ, grid, b.model, tracers)
-# Density(model) = density(model)
-# """
-#     function potential_densityᶜᶜᶜ(i, j, k, grid, b::SeawaterBuoyancy, C, parameters)
-# Compute the potential density of seawater at grid point `(i, j, k)`
-# at reference pressure `parameters.pᵣ` using `SeawaterBuoyancy`.
-# """
-# @inline function potential_densityᶜᶜᶜ(i, j, k, grid, b::SeawaterBuoyancy, C, parameters)
-#     T, S = get_temperature_and_salinity(b, C)
-#     Zᵣ = parameters.Zᵣ
-#     return ρ(i, j, k, grid, b.equation_of_state, T, S, Zᵣ)
-# end
-# potential_density(model, parameters) = potential_density(model.buoyancy, model.grid,
-#                                                          model.tracers, parameters)
-# potential_density(b, grid, tracers, parameters) =
-#     KernelFunctionOperation{Center, Center, Center}(potential_densityᶜᶜᶜ, grid, b.model,
-#                                                     tracers, parameters)
-# PotentialDensity(model, parameters) = potential_density(model, parameters)

--- a/test/kernelfunction_test.jl
+++ b/test/kernelfunction_test.jl
@@ -1,16 +1,8 @@
-using TwoLayerDirectNumericalShenanigans: PotentialDensity, Density
-using Oceananigans: Operators.ℑzᵃᵃᶠ
-using Oceananigans: BuoyancyModels.θ_and_sᴬ
-
-using GibbsSeaWater
-
 diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 100)
 
 model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
                 reference_density = REFERENCE_DENSITY)
-
-z = znodes(model.grid, Center())
 
 T₀ᵘ = -1.5
 S₀ᵘ = 34.568
@@ -19,31 +11,6 @@ initial_conditions = TwoLayerInitialConditions(cabbeling)
 transition_depth = find_depth(model, INTERFACE_LOCATION)
 profile_function = StepChange(transition_depth)
 
-dns = TwoLayerDNS(model, profile_function, initial_conditions)
+tldns = TwoLayerDNS(model, profile_function, initial_conditions)
 
-set_two_layer_initial_conditions!(dns)
-
-reference_pressure = 0
-parameters = (Zᵣ = 0,)
-model = dns.model
-pd_field = Field(PotentialDensity(model, parameters))
-compute!(pd_field)
-
-function test_potential_density_profile(pd_field, computed_density_profile, atol)
-
-    vertical_slice = interior(pd_field, rand(1:10), rand(1:10), :)
-
-    return isapprox.(vertical_slice, computed_density_profile; atol)
-
-end
-
-d_field = Field(Density(model))
-compute!(d_field)
-
-function test_density_profile(d_field, computed_density_profile, atol)
-
-    vertical_slice = interior(d_field, rand(1:10), rand(1:10), :)
-
-    return isapprox.(vertical_slice, computed_density_profile; atol)
-
-end
+set_two_layer_initial_conditions!(tldns)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,24 +180,17 @@ include("output_test.jl")
 
 end
 
-# include("kernelfunction_test.jl")
+include("kernelfunction_test.jl")
 
-# atol = 2e-4 # tolerance for accuracy of density compared to GSW
-# @testset "PotentialDensity field computation" begin
+@testset "Vertical temperature flux" begin
 
-#     σ_profile = gsw_rho.(interior(model.tracers.S, rand(1:10), rand(1:10), :),
-#                          interior(model.tracers.T, rand(1:10), rand(1:10), :),
-#                          reference_pressure)
+    T_anom = Field(TLDNS.tracer_perturbation(tldns.model, tldns.model.tracers.T))
+    compute!(T_anom)
+    computed_mean = sum(interior(model.tracers.T)) / *(size(interior(model.tracers.T))...)
+    computed_T_anom = interior(model.tracers.T) .- computed_mean
+    @test all(computed_T_anom .== interior(T_anom))
+    vtflux = Field(TLDNS.vertical_tracer_flux(tldns.model, tldns.model.tracers.T))
+    compute!(vtflux)
+    @test all(vtflux.data .≈ 0 )
 
-#     @test isequal(trues(length(z)),
-#                   test_potential_density_profile(pd_field, σ_profile, atol))
-# end
-
-# @testset "Density field computation" begin
-
-#     p = gsw_p_from_z.(z, 0)
-#     ρ_profile = gsw_rho.(interior(model.tracers.S, rand(1:10), rand(1:10), :),
-#                          interior(model.tracers.T, rand(1:10), rand(1:10), :), p)
-#     @test isequal(trues(length(ρ_profile)),
-#                    test_density_profile(d_field, ρ_profile, atol))
-# end
+end


### PR DESCRIPTION
This PR adds a `KernelFunctionOperation` to compute the vertical tracer flux of a `model.tracer`. The output is then saved as a horizontally integrated quantity, along with the horizontally integrated vertical temperature gradient, so as to then compute the inferred vertical diffusivity of a `model.tracer`.

The PR also removes no longer needed `KernelFunctionOperations` and tests relating to them.