### PR TITLE
Move `eos` to function argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoLayerDirectNumericalShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/examples/twolayer_example.jl
+++ b/examples/twolayer_example.jl
@@ -6,8 +6,7 @@ diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 100)
 
 ## Setup the model
-model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                 reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
 
 ## set initial conditions
 T₀ᵘ = -1.5
@@ -16,8 +15,6 @@ cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ.cabbeling, T₀ᵘ)
 initial_conditions = TwoLayerInitialConditions(cabbeling)
 transition_depth = find_depth(model, INTERFACE_LOCATION)
 profile_function = StepChange(transition_depth)
-tracer_perturbation_depth = find_depth(model, INTERFACE_LOCATION / 2)
-tracer_perturbation = SalinityGaussianProfile(tracer_perturbation_depth, 0.0, 1.5)
 noise_depth = find_depth(model, INTERFACE_LOCATION)
 initial_noise = SalinityNoise(noise_depth, 1e-2)
 
@@ -26,7 +23,7 @@ tldns = TwoLayerDNS(model, profile_function, initial_conditions; initial_noise)
 set_two_layer_initial_conditions!(tldns)
 
 ## build the simulation
-Δt = 1e-4
+Δt = 1e-2
 stop_time = 60
 save_schedule = 0.5 # seconds
 output_path = joinpath(@__DIR__, "outputs/")

--- a/src/TwoLayerDirectNumericalShenanigans.jl
+++ b/src/TwoLayerDirectNumericalShenanigans.jl
@@ -2,11 +2,10 @@ module TwoLayerDirectNumericalShenanigans
 
 using Oceananigans, Printf, Reexport, JLD2, Rasters, NCDatasets, GibbsSeaWater
 using Oceananigans: AbstractModel, Operators.ℑzᵃᵃᶜ
-using Oceananigans: BuoyancyModels.get_temperature_and_salinity, BuoyancyModels.θ_and_sᴬ,  BuoyancyModels.Zᶜᶜᶜ
-using Oceananigans: BuoyancyModels.buoyancy_perturbationᶜᶜᶜ, BuoyancyModels.∂z_b
 using Oceananigans: Models.seawater_density
-using SeawaterPolynomials
-using SeawaterPolynomials: TEOS10EquationOfState
+using SeawaterPolynomials: BoussinesqEquationOfState
+using SeawaterPolynomials.TEOS10
+using SeawaterPolynomials.SecondOrderSeawaterPolynomials
 import SeawaterPolynomials.ρ
 using SpecialFunctions: erf
 using Oceanostics: KineticEnergyDissipationRate
@@ -14,7 +13,8 @@ using OceanRasterConversions: get_σₚ
 using CUDA: allowscalar, CuArray
 import Base: show, iterate
 
-@reexport using Oceananigans, Reexport
+@reexport using Oceananigans, Reexport, SeawaterPolynomials.TEOS10,
+                SeawaterPolynomials.SecondOrderSeawaterPolynomials
 
 "Abstract type for `TwoLayerDNS`."
 abstract type AbstractTwoLayerDNS end

--- a/test/initialconditions_test.jl
+++ b/test/initialconditions_test.jl
@@ -1,8 +1,7 @@
 # Need to write these to check things are set at the right level in the right field
 diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 500)
-model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
 
 ## set initial conditions, currently there are four options available in this submodule
 initial_conditions = StableTwoLayerInitialConditions(0, 0, 0, 0, 0, 0)

--- a/test/kernelfunction_test.jl
+++ b/test/kernelfunction_test.jl
@@ -1,8 +1,7 @@
 diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 100)
 
-model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                reference_density = REFERENCE_DENSITY)
+model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
 
 T₀ᵘ = -1.5
 S₀ᵘ = 34.568

--- a/test/output_test.jl
+++ b/test/output_test.jl
@@ -3,8 +3,7 @@ function run_sim(save_file)
     diffusivities = (ν = 0, κ = (S = 0, T = 0))
     resolution = (Nx = 10, Ny = 10, Nz = 100)
 
-    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                    reference_density = REFERENCE_DENSITY)
+    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
 
     T₀ᵘ = -1.5
     S₀ᵘ = 34.58

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,8 +65,7 @@ include("initialconditions_test.jl")
 
     for tb ∈ tracer_profile_perturbations
 
-        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                    reference_density = REFERENCE_DENSITY)
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, tracer_perturbation = tb)
         set_two_layer_initial_conditions!(dns)
 
@@ -82,8 +81,7 @@ end
 
     for tb ∈ tracer_blob_perturbations
 
-        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                    reference_density = REFERENCE_DENSITY)
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, tracer_perturbation = tb)
         set_two_layer_initial_conditions!(dns)
 
@@ -96,8 +94,7 @@ end
 
     for tn ∈ tracer_noise_perturbations
 
-        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                    reference_density = REFERENCE_DENSITY)
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, initial_noise = tn)
         set_two_layer_initial_conditions!(dns)
 
@@ -106,8 +103,7 @@ end
     end
     for tnv ∈ tracer_noise_perturbations_vec
 
-        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                    reference_density = REFERENCE_DENSITY)
+        model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
         dns = TwoLayerDNS(model, profile_function, initial_conditions, initial_noise = tnv)
         set_two_layer_initial_conditions!(dns)
 
@@ -119,8 +115,7 @@ end
 
 @testset "Step change" begin
 
-    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities;
-                reference_density = REFERENCE_DENSITY)
+    model = DNSModel(architecture, DOMAIN_EXTENT, resolution, diffusivities)
     profile_function = StepChange(z[depth_idx])
     initial_conditions = TwoLayerInitialConditions(34.551, -1.5, 34.7, 0.5)
     dns = TwoLayerDNS(model, profile_function, initial_conditions)
@@ -137,7 +132,7 @@ end
 end
 
 include("output_test.jl")
-@testset "Saving output" begin
+@testset "Saving and computed output" begin
 
     @testset "NetCDF" begin
         simulation, td, tldns = run_sim(:netcdf)


### PR DESCRIPTION
Previously there was the choice between `TEOS10EquationOfState` and a `LinearEquationOfState`. This PR allows any `BoussinesqEquationOfState` from `SeawaterPolynomials.jl` to be used by having `eos=BoussinesqEquationOfState=TEOS10EquationOfState()` as a function argument with default in `DNSModel` and removing some of the keyword arguments. 

Closes #161 

## Breaking

`DNSModel` no longer accepts keyword arguments for a `LinearEquationOfState` or `reference_density`. Instead these can be set as `eos = BoussinesqEquationOfState` and then passed to `DNSModel`.